### PR TITLE
case-insensitive RE_URL*

### DIFF
--- a/lib/v6/constants.js
+++ b/lib/v6/constants.js
@@ -75,5 +75,5 @@ exports.RE_SUBNET_STRING = /\/\d{1,3}(?=%|$)/;
  */
 exports.RE_ZONE_STRING = /%.*$/;
 
-exports.RE_URL = new RegExp(/^\[{0,1}([0-9a-f:]+)\]{0,1}/);
-exports.RE_URL_WITH_PORT = new RegExp(/\[([0-9a-f:]+)\]:([0-9]{1,5})/);
+exports.RE_URL = new RegExp(/^\[{0,1}([0-9a-f:]+)\]{0,1}/i);
+exports.RE_URL_WITH_PORT = new RegExp(/\[([0-9a-f:]+)\]:([0-9]{1,5})/i);


### PR DESCRIPTION
Change RE_URL* constants to match RE_BAD* case-sensitivity

https://tools.ietf.org/html/rfc5952#section-4.3 says a-f must be lowercase but also says 

  ...but all implementations must accept and be able to handle any legitimate RFC 4291 format.

in the abstract. 4291 lists examples in upper-case but doesnt otherwise touch case-sensitivity

https://tools.ietf.org/html/rfc4291#section-2.2